### PR TITLE
Fix 4 problems with current awparse.php

### DIFF
--- a/awparse.php
+++ b/awparse.php
@@ -351,7 +351,7 @@ class AwstatsMerger extends AwstatsFile
 		{
 			if (!isset($this->data[$section_name][$key]))
 			{
-				$this->data[$key][$key] = $row;
+				$this->data[$section_name][$key] = $row;
 				continue;
 			}
 
@@ -372,7 +372,7 @@ class AwstatsMerger extends AwstatsFile
 		{
 			if (!isset($this->data[$section_name][$key]))
 			{
-				$this->data[$key][$key] = $row;
+				$this->data[$section_name][$key] = $row;
 				continue;
 			}
 

--- a/awparse.php
+++ b/awparse.php
@@ -209,6 +209,15 @@ class AwstatsMerger extends AwstatsFile
 				$this->data['GENERAL'][$item] = $row;
 				continue;
 			}
+			else
+			{
+				if ($item == 'FirstTime')
+					$this->data['GENERAL'][$item][0] = min($row[0], $this->data['GENERAL'][$item][0]);
+				else if (($item == 'LastTime') || ($item == 'LastUpdate'))
+					$this->data['GENERAL'][$item][0] = max($row[0], $this->data['GENERAL'][$item][0]);
+				else if ($item == 'TotalVisits')
+					$this->data['GENERAL'][$item][0] += $row[0];
+			}
 		}
 	}
 

--- a/awparse.php
+++ b/awparse.php
@@ -52,7 +52,7 @@ echo $stats->getFileContents();
  */
 abstract class AwstatsFile
 {
-	protected $data = array();
+	public $data = array();
 
 	public function getFileContents()
 	{


### PR DESCRIPTION
1. Make protected "$data" variable into public because otherwise php 5.1.6 complains access to protected data on line 161.
2. Instead of only taking the first copy of every item in the GENERAL section, merge the FirstTime (min), LastTime (max), LastUpdate (max), and TotalVisits (sum) items since these values are displayed on the awstats web page.
3. Fix bug that caused quite a bit of data to be incorrectly merged due to data references of [$key][$key] instead of [$section_name][$key]
4. Rather than summing all indexes for VISITOR and EXTRA_1 sections, treat 3rd & 4th indexes as dates (take max) and treat 5th as a string (take the first one).
